### PR TITLE
Better Handle Streams with Local Files (OSK-3)

### DIFF
--- a/src/OSK.Storage.Local.UnitTests/Helpers/TestFixtures/FileStorageFixture.cs
+++ b/src/OSK.Storage.Local.UnitTests/Helpers/TestFixtures/FileStorageFixture.cs
@@ -5,27 +5,37 @@ namespace OSK.Storage.Local.UnitTests.Helpers.TestFixtures
 {
     public class FileStorageFixture : IDisposable
     {
-        public static readonly string TestDirectory = Path.Combine(".", "TestData");
+        private static readonly string TestDirectoryTemplate = Path.Combine(".", "TestData");
         private Encoding _encoding = Encoding.UTF8;
+
+        private string _testDirectory;
 
         public FileStorageFixture()
         {
-            Directory.CreateDirectory(TestDirectory);
+            NewDirectory();
+        }
 
-            Assert.True(Directory.Exists(TestDirectory));
+        public void NewDirectory()
+        {
+            _testDirectory = TestDirectoryTemplate;
+            Directory.CreateDirectory(_testDirectory);
+
+            Assert.True(Directory.Exists(_testDirectory));
         }
 
         public void Dispose()
         {
-            if (Directory.Exists(TestDirectory))
+            if (Directory.Exists(_testDirectory))
             {
-                Directory.Delete(TestDirectory, true);
+                Directory.Delete(_testDirectory, true);
             }
 
-            Assert.False(Directory.Exists(TestDirectory));
+            Assert.False(Directory.Exists(_testDirectory));
         }
 
         #region Helpers
+
+        public string TestDirectory => _testDirectory;
 
         public void SetEncoding(Encoding encoding)
         {
@@ -51,6 +61,7 @@ namespace OSK.Storage.Local.UnitTests.Helpers.TestFixtures
         public string CreateTestFile(string fileNameWithoutExtension, string content, string extension = ".txt")
         {
             var filePath = GetFilePath($"{fileNameWithoutExtension}{extension}");
+
             using var fileStream = File.Create(filePath);
 
             fileStream.Write(_encoding.GetBytes(content));
@@ -60,12 +71,12 @@ namespace OSK.Storage.Local.UnitTests.Helpers.TestFixtures
 
         public string GetFilePath(string fileNameWithExtension)
         {
-            return Path.Combine(TestDirectory, fileNameWithExtension);
+            return Path.Combine(_testDirectory, fileNameWithExtension);
         }
 
         public void ClearTestDirectory()
         {
-            var directoryInfo = new DirectoryInfo(TestDirectory);
+            var directoryInfo = new DirectoryInfo(_testDirectory);
             foreach (var file in directoryInfo.GetFiles())
             {
                 file.Delete();
@@ -75,7 +86,7 @@ namespace OSK.Storage.Local.UnitTests.Helpers.TestFixtures
                 dir.Delete(true);
             }
 
-            var directoryExists = Directory.Exists(TestDirectory);
+            var directoryExists = Directory.Exists(_testDirectory);
 
             Assert.True(directoryExists);
         }

--- a/src/OSK.Storage.Local/Models/LocalStorageFile.cs
+++ b/src/OSK.Storage.Local/Models/LocalStorageFile.cs
@@ -1,13 +1,19 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace OSK.Storage.Local.Models
 {
-    public class LocalStorageFile
+    public class LocalStorageFile: IDisposable
     {
         public long Size { get; set; }
 
         public bool IsEncrypted { get; set; }
 
         public Stream DataStream { get; set; }
+
+        public void Dispose()
+        {
+            DataStream?.Dispose();
+        }
     }
 }

--- a/src/OSK.Storage.Local/Models/LocalStorageObject.cs
+++ b/src/OSK.Storage.Local/Models/LocalStorageObject.cs
@@ -1,9 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using OSK.Functions.Outputs.Abstractions;
 using OSK.Serialization.Abstractions;
 using OSK.Storage.Abstractions;
 using OSK.Storage.Local.Ports;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,16 +37,51 @@ namespace OSK.Storage.Local.Models
         {
             var serializerProvider = _serviceProvider.GetRequiredService<ISerializerProvider>();
             var serializer = serializerProvider.GetSerializer(MetaData.FullStoragePath);
+            var dataProcessors = _serviceProvider.GetService<IEnumerable<IRawDataProcessor>>() 
+                ?? Enumerable.Empty<IRawDataProcessor>();
 
+            var decrypted = !MetaData.IsEncrypted;
+            var streamBytes = await ReadStreamBytesAsync(cancellationToken);
+            foreach (var dataProcessor in dataProcessors.Reverse())
+            {
+                var dataResult = await dataProcessor.ProcessPreDeserializationAsync(streamBytes, cancellationToken);
+                if (!dataResult.IsSuccessful)
+                {
+                    throw new InvalidOperationException($"An error occurred attempting to derialize the storage object's stream: {dataResult.GetErrorString()}");
+                }
+
+                streamBytes = dataResult.Value;
+                if (dataProcessor is ICryptographicRawDataProcessor)
+                {
+                    decrypted = true;
+                }
+            }
+
+            if (!decrypted)
+            {
+                throw new InvalidOperationException("Unable to deserialize an encrypted stream.");
+            }
+
+            return await serializer.DeserializeAsync<T>(streamBytes, cancellationToken);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private async ValueTask<byte[]> ReadStreamBytesAsync(CancellationToken cancellationToken)
+        {
             if (Value is MemoryStream memoryStream)
             {
-                return await serializer.DeserializeAsync<T>(memoryStream.ToArray(), cancellationToken);
+                return memoryStream.ToArray();
             }
 
             using var copyStream = new MemoryStream();
             await Value.CopyToAsync(copyStream, cancellationToken);
-
-            return await serializer.DeserializeAsync<T>(copyStream.ToArray(), cancellationToken);
+            await Value.FlushAsync(cancellationToken);
+            var array = copyStream.ToArray();
+            Value.Dispose();
+            return array;
         }
 
         #endregion


### PR DESCRIPTION
Motivation
----
Current mechanism for loading meta data and storage objects locally involves reading all bytes of a file immediately, despite it not being required

Modifications
----
* Updated LocalStorageService to avoid reading all bytes to get meta data
* Updated LocalStorageObject to utilize the raw data processors when being requested to read the entire stream. This also helps to keep encrypted data secure until the moment it is required to consume
* Updated UnitTests as necessary

Result
----
Getting meta data locally does not require reading all bytes of a file immediately

Fixes #3