### PR TITLE
Custom Extension Serialization, Vulnerability, and Docs Update (OSK-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # OSK.Storage.Local
-An implementation of a storage service that is specific to local machine storage
+
+The projects are meant to provide a quick and useful way of saving and handling a variety of files via dependency injection. Through the various serializers, data can be saved using
+JSON, YAML, binary, or any other format that integrates with the `ISerializer` interface. This project focuses on storage to a local device and does not
+interact with cloud technologies. Additionally, through the use of dependency injection, various data manipulations, polymorphism, and other features can be added as needed for consumers.
+ 
+# Local
+This is the core logic of the project. It adds all the necessary services using the `AddLocalStorage` extension. 
+
+The process for saving a file flows in the following:
+* Caller calls the `ILocalStorageService` to save some data, using a set of save options
+* Data is validated and then converted using one of the `ISerializer` objects within the dependency container
+* After the data is converted into raw data from a serializer, the data is then processed through a list of `IRawDataProcessor` objects. These can manipulate the data further to allow for compression, encryption, etc.
+
+The process for loadingn a file flows in the following:
+* Call calls the `ILocalStorageService` to load some data
+* Data is pulled from the location passed and ran through the list of `IRawDataProcessor` objects to reverse the data manipulations performed during saving.
+* Data is then passed into the serializer to be converted into a useful object
+
+
+# Snappier
+Since data size can become an issue, snappier is a useful tool that helps to compress data quickly and efficiently in C#. You view more information and the library here https://github.com/brantburnett/Snappier
+This project provides an integration to the `ILocalStorageService` to using this compression algorithm. By using the `AddLocalStorageSnappierCompression` extension, an `IRawDataProcessor` will be added to the dependency contaioner to be used during the local data manipulation processes prior to storage.
+
+# Cryptography
+For security needs, a cryptography integration exists that utilizes the `OSK.Security.Cryptography` codebase. By using the `AddLocalStorageCryptography` extension, the `ILocalStorageService` will gain access to a cryptographic data processor that handle encryption and decryption of data, using any of the
+integrations for the cryptoraphic library. In order to fully utilize this extension, consumers will need to create an implementation for the `ICryptographicKeyRepository` and add it to the dependency container. This is used to retrieve the necessary key information
+for the application to encrypt local data.
+
+# Default Local Configuration
+For consumers simply wanting access to a local storage service capable of handling binary, json, and yaml, without wanting to perform custom dependency setups, this project provides a quick convenience method to add
+an implementation for these serializers for you, but it does add dependencies to the OSK serializers implementations, which is why the project is separated so consumers can decide to add those dependencies or not. By calling
+`AddLocalStorageDefaultSerializers`, consumers will be able to setup the entirety of a `ILocalStorageService` dependency tree using the default configuration in the project.
+
+# Default Polymorphism Configuration
+In the even local storage is handling abstraction and other generic data, polymorhpism will be necessary in order to fully deserialized the objects into the correct types. This project provides a default setup with the `OSK.Serialization.Polymorphism` codebase 
+and will setup an `Enum` based polymorphism strategy (see https://github.com/OpenSourceKingdom/OSK.Serialization.Polymorphism.Discriminators). To use this feature, consumers will want to use the
+`AddLocalStorageDefaultPolymorphism` extension and provide an assembly type marker
+
+# Contributions and Issues
+Any and all contributions are appreciated! Please be sure to follow the branch naming convention OSK-{issue number}-{deliminated}-{branch}-{name} as current workflows rely on it for automatic issue closure. Please submit issues for discussion and tracking using the github issue tracker.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+	<PropertyGroup>	
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Storage.Local</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>CS1591</NoWarn>
+		<Authors>BlankDev117</Authors>
+	</PropertyGroup>
+  
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+	</ItemGroup>
+</Project>

--- a/src/OSK.Storage.Local.Compression.Snappier/OSK.Storage.Local.Compression.Snappier.csproj
+++ b/src/OSK.Storage.Local.Compression.Snappier/OSK.Storage.Local.Compression.Snappier.csproj
@@ -2,18 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Storage.Local</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<Description>
 			An extension for OSK.Storage.Local service that adds an integration for compression
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Compression, Data, Snappy</PackageTags>
-		<Authors>BlankDev117</Authors>
 		<Title>OSK.Storage.Local.Compression.Snappier</Title>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
+++ b/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
@@ -2,18 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Storage.Local</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<Description>
 			An extension for OSK.Storage.Local service that adds an integration for cryptography
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Security, Encryption, Decryption, Cryptography</PackageTags>
-		<Authors>BlankDev117</Authors>
 		<Title>OSK.Storage.Local.Cryptography</Title>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
+++ b/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OSK.Security.Cryptography" Version="1.2.0" />
-		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.0.1" />
+		<PackageReference Include="OSK.Security.Cryptography" Version="2.1.0" />
+		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.Cryptography/Ports/ICryptographicKeyRepository.cs
+++ b/src/OSK.Storage.Local.Cryptography/Ports/ICryptographicKeyRepository.cs
@@ -1,9 +1,14 @@
-﻿using OSK.Security.Cryptography.Abstractions;
+﻿using OSK.Hexagonal.MetaData;
+using OSK.Security.Cryptography.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace OSK.Storage.Local.Cryptography.Ports
 {
+    /// <summary>
+    /// A key repository that provides a cryptographic key to a cryptographic data processor when data manipulations are happening prior to storage"/>
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ICryptographicKeyRepository
     {
         ValueTask<ICryptographicKeyInformation> GetCryptographicKeyAsync(CancellationToken cancellationToken = default);

--- a/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
@@ -2,20 +2,13 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Storage.Local</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<Description>
 			Adds default configuration for Binary, Yaml, and Json polymorphism to the OSK local storage service
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Default, Polymorphism</PackageTags>
-		<Authors>BlankDev117</Authors>
 		<Title>OSK.Storage.Local.DefaultConfiguration.Polymorphism</Title>
 	</PropertyGroup>
-
-	<PropertyGroup>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
-
+	
 	<ItemGroup>
 		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />

--- a/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.0" />
-		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.0" />
+		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.1" />
+		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />
 	</ItemGroup>
 

--- a/src/OSK.Storage.Local.DefaultConfiguration/OSK.Storage.Local.DefaultConfiguration.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration/OSK.Storage.Local.DefaultConfiguration.csproj
@@ -17,9 +17,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.0" />
-		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.0" />
-		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.1" />
+		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
+		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
+		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.DefaultConfiguration/OSK.Storage.Local.DefaultConfiguration.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration/OSK.Storage.Local.DefaultConfiguration.csproj
@@ -2,18 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Storage.Local</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<Description>
 			Adds default configuration for Binary, Yaml, and Json serializers to the OSK local storage service
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Default, Serializers</PackageTags>
-		<Authors>BlankDev117</Authors>
 		<Title>OSK.Storage.Local.DefaultConfiguration</Title>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.UnitTests/Internal/Services/EndToEnd.cs
+++ b/src/OSK.Storage.Local.UnitTests/Internal/Services/EndToEnd.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OSK.Extensions.Serialization.SystemTextJson.Polymorphism;
 using OSK.Extensions.Serialization.YamlDotNet.Polymorphism;
+using OSK.Serialization.Abstractions.Json;
 using OSK.Serialization.Binary.Sharp;
 using OSK.Serialization.Json.SystemTextJson;
 using OSK.Serialization.Polymorphism.Discriminators;
@@ -117,7 +118,8 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
 
                 services
                     .AddLocalStorageCryptography()
-                    .AddLocalStorageSnappierCompression();
+                    .AddLocalStorageSnappierCompression()
+                    .AddSerializerExtensionDescriptor<IJsonSerializer>(".testExtension");
             });
 
             var file = new TestFile()
@@ -160,6 +162,12 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             });
             Assert.True(result4.IsSuccessful);
 
+            var result5 = await storageService.SaveAsync(file, FileStorageFixture.GetFilePath("test.testExtension"), new LocalSaveOptions()
+            {
+                SavePermissions = SavePermissionType.AllowOverwrite
+            });
+            Assert.True(result5.IsSuccessful);
+
             var jsonResult = await storageService.GetAsync(FileStorageFixture.GetFilePath("test.json"));
             Assert.True(jsonResult.IsSuccessful);
             using var o = jsonResult.Value;
@@ -179,6 +187,11 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             Assert.True(unknownResult.IsSuccessful);
             using var o3 = unknownResult.Value;
             _ = await o3.StreamAsAsync<TestFile>();
+
+            var customResult = await storageService.GetAsync(FileStorageFixture.GetFilePath("test.testExtension"));
+            Assert.True(customResult.IsSuccessful);
+            using var o4 = customResult.Value;
+            _ = await o4.StreamAsAsync<TestFile>();
         }
 
         #region Helpers

--- a/src/OSK.Storage.Local.UnitTests/Internal/Services/LocalStorageServiceTests.cs
+++ b/src/OSK.Storage.Local.UnitTests/Internal/Services/LocalStorageServiceTests.cs
@@ -62,7 +62,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         #region SaveAsync
 
         [Fact]
-        public async void SaveAsync_NullData_ThrowsArgumentNullException()
+        public async Task SaveAsync_NullData_ThrowsArgumentNullException()
         {
             // Arrange
             var filePath = _fileStorageFixture.GetFilePath("Test");
@@ -72,21 +72,21 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_NullFilePath_ThrowsArgumentNullException()
+        public async Task SaveAsync_NullFilePath_ThrowsArgumentNullException()
         {
             // Arrange/Act/Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _localStorageService.SaveAsync("Test", null, new LocalSaveOptions()));
         }
 
         [Fact]
-        public async void SaveAsync_EmptyFilePath_ThrowsArgumentNullException()
+        public async Task SaveAsync_EmptyFilePath_ThrowsArgumentNullException()
         {
             // Arrange/Act/Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _localStorageService.SaveAsync("Test", "", new LocalSaveOptions()));
         }
 
         [Fact]
-        public async void SaveAsync_NullStorageOptions_ThrowsArgumentNullException()
+        public async Task SaveAsync_NullStorageOptions_ThrowsArgumentNullException()
         {
             // Arrange
             var filePath = _fileStorageFixture.GetFilePath("Test");
@@ -97,7 +97,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_EncryptionRequestWithoutICryptographicRawDataProcessor_ThrowsArgumentNullException()
+        public async Task SaveAsync_EncryptionRequestWithoutICryptographicRawDataProcessor_ThrowsArgumentNullException()
         {
             // Arrange
             var filePath = _fileStorageFixture.GetFilePath("Test");
@@ -111,7 +111,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_FileExistsNoOverwritePermission_ReturnsError()
+        public async Task SaveAsync_FileExistsNoOverwritePermission_ReturnsError()
         {
             // Arrange
             var testFilePath = _fileStorageFixture.CreateTestFile("testTextFile", "Test");
@@ -130,7 +130,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_FileDoesNotExist_UsesEncryption_EncryptingError_ReturnsError()
+        public async Task SaveAsync_FileDoesNotExist_UsesEncryption_EncryptingError_ReturnsError()
         {
             // Arrange
             _mockBinarySerializer.Setup(m => m.SerializeAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
@@ -159,7 +159,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_FileDoesNotExist_NoEncryption_ReturnsSuccess()
+        public async Task SaveAsync_FileDoesNotExist_NoEncryption_ReturnsSuccess()
         {
             // Arrange
             _mockBinarySerializer.Setup(m => m.SerializeAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
@@ -188,7 +188,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_FileExistsOverwritingAllowed_NoEncryption_ReturnsSuccess()
+        public async Task SaveAsync_FileExistsOverwritingAllowed_NoEncryption_ReturnsSuccess()
         {
             // Arrange
             _mockBinarySerializer.Setup(m => m.SerializeAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
@@ -218,7 +218,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void SaveAsync_FileDoesNotExist_UsesEncryption_ReturnsSuccess()
+        public async Task SaveAsync_FileDoesNotExist_UsesEncryption_ReturnsSuccess()
         {
             // Arrange
             _mockBinarySerializer.Setup(m => m.SerializeAsync(It.IsAny<object>(), It.IsAny<CancellationToken>()))
@@ -259,21 +259,21 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         #region GetAsync
 
         [Fact]
-        public async void GetAsync_NullFilePath_ThrowsArgumentNullException()
+        public async Task GetAsync_NullFilePath_ThrowsArgumentNullException()
         {
             // Assert/Act/Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _localStorageService.GetAsync(null));
         }
 
         [Fact]
-        public async void GetAsync_EmptyFilePath_ThrowsArgumentNullException()
+        public async Task GetAsync_EmptyFilePath_ThrowsArgumentNullException()
         {
             // Arrange/Act/Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _localStorageService.GetAsync(""));
         }
 
         [Fact]
-        public async void GetAsync_FilePathDoesNotExist_ReturnsError()
+        public async Task GetAsync_FilePathDoesNotExist_ReturnsError()
         {
             // Act
             var result = await _localStorageService.GetAsync("NotARealPath");
@@ -284,7 +284,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void GetAsync_FilePathExists_IsEncrypted_DecryptionReturnsError()
+        public async Task GetAsync_FilePathExists_IsEncrypted_DecryptionReturnsError()
         {
             // Arrange
             var text = "Test text for file exists";
@@ -326,7 +326,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void GetAsync_FilePathExists_NotEncrypted_ReturnsSuccess()
+        public async Task GetAsync_FilePathExists_NotEncrypted_ReturnsSuccess()
         {
             // Arrange
             _mockBinarySerializer.Setup(m => m.DeserializeAsync(It.IsAny<byte[]>(), It.IsAny<Type>(), It.IsAny<CancellationToken>()))
@@ -363,14 +363,14 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public async void GetStorageDetailsAsync_InvalidDirectoryPath_ThrowsArgumentNullException(string path)
+        public async Task GetStorageDetailsAsync_InvalidDirectoryPath_ThrowsArgumentNullException(string path)
         {
             // Arrange/Act/Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _localStorageService.GetStorageDetailsAsync(path, null));
         }
 
         [Fact]
-        public async void GetStorageDetailsAsync_DirectoryPathDoesNotExist_ReturnsError()
+        public async Task GetStorageDetailsAsync_DirectoryPathDoesNotExist_ReturnsError()
         {
             // Act
             var result = await _localStorageService.GetStorageDetailsAsync("bad/Path", null);
@@ -380,7 +380,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void GetStorageDetailsAsync_EmptyDirectory_ReturnsEmptyList()
+        public async Task GetStorageDetailsAsync_EmptyDirectory_ReturnsEmptyList()
         {
             // Act
             var result = await _localStorageService.GetStorageDetailsAsync(_fileStorageFixture.TestDirectory, null);
@@ -391,7 +391,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void GetStorageDetailsAsync_DirectoryHasObjects_NoExtension_ReturnsllFiles()
+        public async Task GetStorageDetailsAsync_DirectoryHasObjects_NoExtension_ReturnsllFiles()
         {
             // Arrange
             var testTexts = new[]
@@ -446,7 +446,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void GetStorageDetailsAsync_DirectoryHasObjects_Extension_ReturnsFilesWithExtension()
+        public async Task GetStorageDetailsAsync_DirectoryHasObjects_Extension_ReturnsFilesWithExtension()
         {
             // Arrange
             var testTexts = new[]
@@ -497,7 +497,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public async void DeleteAsync_NullAndEmptyString_ReturnsSuccess(string path)
+        public async Task DeleteAsync_NullAndEmptyString_ReturnsSuccess(string path)
         {
             // Act
             var result = await _localStorageService.DeleteAsync(path);
@@ -507,7 +507,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void DeleteAsync_PathDoesNotExist_ReturnsSuccess()
+        public async Task DeleteAsync_PathDoesNotExist_ReturnsSuccess()
         {
             // Act
             var result = await _localStorageService.DeleteAsync("bad/path");
@@ -517,7 +517,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         }
 
         [Fact]
-        public async void DeleteAsync_PathExists_DeletesFile_ReturnsSuccess()
+        public async Task DeleteAsync_PathExists_DeletesFile_ReturnsSuccess()
         {
             // Arrange
             var testFilePath = _fileStorageFixture.CreateTestFile("testFile", "test");
@@ -537,7 +537,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         #region e2e
 
         [Fact]
-        public async void E2E_SaveFollowedByGet_ReturnsExpectedValue()
+        public async Task E2E_SaveFollowedByGet_ReturnsExpectedValue()
         {
             var testObj = new TestFile()
             {

--- a/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
+++ b/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
@@ -6,20 +6,20 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.0" />
-		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.0" />
-		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.2.1" />
-		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.0" />
-		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.1" />
+		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.1" />
+		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
+		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />
-		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.1" />
-		<PackageReference Include="xunit" Version="2.7.0" />
-		<PackageReference Include="Moq" Version="4.20.70" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.2" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/OSK.Storage.Local/Models/SerializerExtensionDescriptor.cs
+++ b/src/OSK.Storage.Local/Models/SerializerExtensionDescriptor.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OSK.Storage.Local.Models
+{
+    public class SerializerExtensionDescriptor
+    {
+        public Type SerializerType { get; set; }
+
+        public ISet<string> Extensions { get; set; }
+    }
+}

--- a/src/OSK.Storage.Local/OSK.Storage.Local.csproj
+++ b/src/OSK.Storage.Local/OSK.Storage.Local.csproj
@@ -2,18 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Storage.Local</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<Description>
 			An implementation of a storage service that is specific to local machine storage in .NET
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Data, Object, Storage, Saving, Loading, Delete, Get, Serialize, Deserialize, Local, LocalHost</PackageTags>
-		<Authors>BlankDev117</Authors>
 		<Title>OSK.Storage.Local</Title>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local/OSK.Storage.Local.csproj
+++ b/src/OSK.Storage.Local/OSK.Storage.Local.csproj
@@ -17,14 +17,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 		<PackageReference Include="MimeTypesMap" Version="1.0.8" />
-		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.2.1" />
-		<PackageReference Include="OSK.Serialization.Abstractions" Version="1.1.2" />
-		<PackageReference Include="OSK.Serialization.Abstractions.Binary" Version="1.1.2" />
-		<PackageReference Include="OSK.Serialization.Abstractions.Json" Version="1.1.2" />
-		<PackageReference Include="OSK.Serialization.Abstractions.Yaml" Version="1.1.2" />
-		<PackageReference Include="OSK.Storage.Abstractions" Version="1.0.2" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.5.1" />
+		<PackageReference Include="OSK.Serialization.Abstractions" Version="1.1.3" />
+		<PackageReference Include="OSK.Serialization.Abstractions.Binary" Version="1.1.3" />
+		<PackageReference Include="OSK.Serialization.Abstractions.Json" Version="1.1.3" />
+		<PackageReference Include="OSK.Serialization.Abstractions.Yaml" Version="1.1.3" />
+		<PackageReference Include="OSK.Storage.Abstractions" Version="1.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Storage.Local/Ports/ICryptographicRawDataProcessor.cs
+++ b/src/OSK.Storage.Local/Ports/ICryptographicRawDataProcessor.cs
@@ -1,5 +1,11 @@
-﻿namespace OSK.Storage.Local.Ports
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Storage.Local.Ports
 {
+    /// <summary>
+    /// Represents a <see cref="IRawDataProcessor"/> that is focused on cryptographic encryption functions. This is meant to be used for encryption related purposes; for non-ecryption cryptographic purposes, please add a <see cref="IRawDataProcessor"/> instead. 
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ICryptographicRawDataProcessor: IRawDataProcessor
     {
     }

--- a/src/OSK.Storage.Local/Ports/ILocalStorageService.cs
+++ b/src/OSK.Storage.Local/Ports/ILocalStorageService.cs
@@ -1,8 +1,10 @@
-﻿using OSK.Storage.Abstractions;
+﻿using OSK.Hexagonal.MetaData;
+using OSK.Storage.Abstractions;
 using OSK.Storage.Local.Options;
 
 namespace OSK.Storage.Local.Ports
 {
+    [HexagonalPort(HexagonalPort.Primary)]
     public interface ILocalStorageService : IStorageService<LocalSaveOptions, FileSearchOptions>
     {
     }

--- a/src/OSK.Storage.Local/Ports/IRawDataProcessor.cs
+++ b/src/OSK.Storage.Local/Ports/IRawDataProcessor.cs
@@ -1,13 +1,33 @@
 ﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.Hexagonal.MetaData;
+using OSK.Serialization.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace OSK.Storage.Local.Ports
 {
+    /// <summary>
+    /// A data processor that is used either before an <see cref="ISerializer"/> deserializes or after serialization on the raw data represented by a given object.
+    /// This provides methods for serialization and deserialization to ensure that any processing for storage can be reversed if necessary so the raw data can be 
+    /// successfully converted back into an object
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface IRawDataProcessor
     {
+        /// <summary>
+        /// This method is triggered after an object has been converted into raw data and is ran prior to being stored
+        /// </summary>
+        /// <param name="data">The raw data for the serialized object</param>
+        /// <param name="cancellationToken">A token for cancelling the operation</param>
+        /// <returns>An output of processing of the data. This should return the processed data, if anything occurred to it directly.</returns>
         ValueTask<IOutput<byte[]>> ProcessPostSerializationAsync(byte[] data, CancellationToken cancellationToken = default);
-         
+
+        /// <summary>
+        /// This method is triggered before raw data is converted into an object and is ran after being loaded into memory
+        /// </summary>
+        /// <param name="data">The raw data for an object</param>
+        /// <param name="cancellationToken">A token for cancelling the operation</param>
+        /// <returns>An output of processing of the data. This should return the processed data, if anything occurred to it directly.</returns>
         ValueTask<IOutput<byte[]>> ProcessPreDeserializationAsync(byte[] data, CancellationToken cancellationToken = default);
     }
 }

--- a/src/OSK.Storage.Local/Ports/ISerializerProvider.cs
+++ b/src/OSK.Storage.Local/Ports/ISerializerProvider.cs
@@ -1,7 +1,12 @@
-﻿using OSK.Serialization.Abstractions;
+﻿using OSK.Hexagonal.MetaData;
+using OSK.Serialization.Abstractions;
 
 namespace OSK.Storage.Local.Ports
 {
+    /// <summary>
+    /// Retrives a valid <see cref="ISerializer"/> that is capable of serializing and deserializing a given file path
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Primary)]
     public interface ISerializerProvider
     {
         ISerializer GetSerializer(string filePath);

--- a/src/OSK.Storage.Local/ServiceCollectionExtensions.cs
+++ b/src/OSK.Storage.Local/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OSK.Functions.Outputs.Logging;
 using OSK.Storage.Local.Internal.Services;
+using OSK.Storage.Local.Models;
 using OSK.Storage.Local.Ports;
 
 namespace OSK.Storage.Local
@@ -11,21 +13,19 @@ namespace OSK.Storage.Local
         public static IServiceCollection AddLocalStorage(this IServiceCollection services)
         {
             services.AddLoggingFunctionOutputs();
-            services
-                    .TryAddTransient<ILocalStorageService, LocalStorageService>();
+            services.TryAddTransient<ILocalStorageService, LocalStorageService>();
             services.TryAddTransient<ISerializerProvider, SerializerProvider>();
 
-            /*
-              
-             
-                    .AddBinarySerialization()
-                    .AddJsonSerialization()
-                    .AddYamlSerialization()
-                    .AddPolymorphismEnumDiscriminatorStrategy()
-                    .AddYamlPolymorphism()
-                    .AddJsonPolymorphismConverter() 
-             
-             */
+            return services;
+        }
+
+        public static IServiceCollection AddSerializerExtensionDescriptor<ISerializer>(this IServiceCollection services, params string[] extensions)
+        {
+            services.AddTransient(_ => new SerializerExtensionDescriptor()
+            {
+                Extensions = extensions.ToHashSet(),
+                SerializerType = typeof(ISerializer)
+            });
 
             return services;
         }


### PR DESCRIPTION
Motivation
----
The project currently has some known security vulnerabilities that need to be patched as well as no good way to set serializers for unique extensions beyond json, yaml, and binary. There is also a lack of documentation in the project.

Modifications
----
* Updated all packages with known security vulnerabilities
* Added a mechanism to associate `ISerializer`s with custom extensions
* Add better readme/comments

Result
----
Vulnerability issues should be patched, better documentation, and a new way to set serializers per extension should be finished

Fixes #5