### PR TITLE
Fixing some readme typos (OSK-7)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,8 +7,4 @@
 		<NoWarn>CS1591</NoWarn>
 		<Authors>BlankDev117</Authors>
 	</PropertyGroup>
-  
-	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-	</ItemGroup>
 </Project>

--- a/src/OSK.Storage.Local.Compression.Snappier/OSK.Storage.Local.Compression.Snappier.csproj
+++ b/src/OSK.Storage.Local.Compression.Snappier/OSK.Storage.Local.Compression.Snappier.csproj
@@ -7,9 +7,11 @@
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Compression, Data, Snappy</PackageTags>
 		<Title>OSK.Storage.Local.Compression.Snappier</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<PackageReference Include="Snappier" Version="1.1.6" />
 	</ItemGroup>
 

--- a/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
+++ b/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
@@ -7,9 +7,11 @@
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Security, Encryption, Decryption, Cryptography</PackageTags>
 		<Title>OSK.Storage.Local.Cryptography</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<PackageReference Include="OSK.Security.Cryptography" Version="2.1.0" />
 		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.1.0" />
 	</ItemGroup>

--- a/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
@@ -7,9 +7,11 @@
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Default, Polymorphism</PackageTags>
 		<Title>OSK.Storage.Local.DefaultConfiguration.Polymorphism</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 	
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />

--- a/src/OSK.Storage.Local.DefaultConfiguration/OSK.Storage.Local.DefaultConfiguration.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration/OSK.Storage.Local.DefaultConfiguration.csproj
@@ -7,9 +7,11 @@
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Local, LocalHost, Default, Serializers</PackageTags>
 		<Title>OSK.Storage.Local.DefaultConfiguration</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-
+	
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.2" />

--- a/src/OSK.Storage.Local/OSK.Storage.Local.csproj
+++ b/src/OSK.Storage.Local/OSK.Storage.Local.csproj
@@ -7,9 +7,11 @@
 		</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, Data, Object, Storage, Saving, Loading, Delete, Get, Serialize, Deserialize, Local, LocalHost</PackageTags>
 		<Title>OSK.Storage.Local</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-
+	
 	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 		<PackageReference Include="MimeTypesMap" Version="1.0.8" />
 		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.5.1" />


### PR DESCRIPTION
Motivation
----
The readme has some typos and isn't showing as expected

Modifications
----
* Updated readme/etc.

Result
----
readme shows as expected

Fixes #7