### PR TITLE
Case insensitive json Polymorphic deserialization (OSK-9)

### DIFF
--- a/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
+++ b/src/OSK.Storage.Local.DefaultConfiguration.Polymorphism/OSK.Storage.Local.DefaultConfiguration.Polymorphism.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.1" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />
 	</ItemGroup>

--- a/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
+++ b/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
@@ -10,9 +10,9 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.1" />
+		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
-		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.2" />
 		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />

--- a/src/OSK.Storage.Local/OSK.Storage.Local.csproj
+++ b/src/OSK.Storage.Local/OSK.Storage.Local.csproj
@@ -11,10 +11,10 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 		<PackageReference Include="MimeTypesMap" Version="1.0.8" />
-		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.5.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.5.2" />
 		<PackageReference Include="OSK.Serialization.Abstractions" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Binary" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Json" Version="1.1.3" />


### PR DESCRIPTION
Motivation
----
Recent changes fix a problem with deserialization using JSON with case sensitivity issues

Modifications
----
* Updated packages

Result
----
Case sensitivity is no longer forced if not set on Json serializaer options

Fixes #9