### PR TITLE
Fix data processing on StreamAsAsync method (OSK-11)

### DIFF
--- a/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
+++ b/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
@@ -88,6 +88,11 @@ namespace OSK.Storage.Local.Internal.Services
             {
                 foreach (var dataProcessor in _dataProcessors)
                 {
+                    if (!options.Encrypt && dataProcessor is ICryptographicRawDataProcessor)
+                    {
+                        continue;
+                    }
+
                     var dataResult = await dataProcessor.ProcessPostSerializationAsync(serializedData, cancellationToken);
                     if (!dataResult.IsSuccessful)
                     {

--- a/src/OSK.Storage.Local/Models/LocalStorageObject.cs
+++ b/src/OSK.Storage.Local/Models/LocalStorageObject.cs
@@ -44,6 +44,11 @@ namespace OSK.Storage.Local.Models
             var streamBytes = await ReadStreamBytesAsync(cancellationToken);
             foreach (var dataProcessor in dataProcessors.Reverse())
             {
+                if (decrypted && dataProcessor is ICryptographicRawDataProcessor)
+                {
+                    continue;
+                }
+
                 var dataResult = await dataProcessor.ProcessPreDeserializationAsync(streamBytes, cancellationToken);
                 if (!dataResult.IsSuccessful)
                 {


### PR DESCRIPTION
Motivation
----
Current StreamAsAsync and SaveAsync method is always using a cryptographic data processor if it is available even if isn't necessary, causing unexpected issues when deserializing data

Modifications
----
* Only use the cryptographic data processor if it is necessary when serializing and deserializing

Result
----
Data serialization issues are resolved

Fixes #11