### PR TITLE
Update for better cryptography extension handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project provides an integration to the `ILocalStorageService` to using this
 # Cryptography
 For security needs, a cryptography integration exists that utilizes the `OSK.Security.Cryptography` codebase. By using the `AddLocalStorageCryptography` extension, the `ILocalStorageService` will gain access to a cryptographic data processor that handle encryption and decryption of data, using any of the
 integrations for the cryptoraphic library. In order to fully utilize this extension, consumers will need to create an implementation for the `ICryptographicKeyRepository` and add it to the dependency container. This is used to retrieve the necessary key information
-for the application to encrypt local data.
+for the application to encrypt local data. Additionally, consumers should also add an implementation of a cryptographic algorithm so that it can be used for encryption/decryption
 
 # Default Local Configuration
 For consumers simply wanting access to a local storage service capable of handling binary, json, and yaml, without wanting to perform custom dependency setups, this project provides a quick convenience method to add

--- a/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
+++ b/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
@@ -11,13 +11,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<PackageReference Include="OSK.Security.Cryptography" Version="2.1.0" />
-		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\OSK.Storage.Local\OSK.Storage.Local.csproj" />
+	  <ProjectReference Include="..\OSK.Storage.Local\OSK.Storage.Local.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Storage.Local.Cryptography/ServiceCollectionExtensions.cs
+++ b/src/OSK.Storage.Local.Cryptography/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using OSK.Security.Cryptography.Aes;
 using OSK.Storage.Local.Cryptography.Internal.Services;
 
 namespace OSK.Storage.Local.Cryptography
@@ -8,7 +7,6 @@ namespace OSK.Storage.Local.Cryptography
     {
         public static IServiceCollection AddLocalStorageCryptography(this IServiceCollection services)
         {
-            services.AddAesKeyService();
             services.AddSerializationRawDataProcessor<CryptographySerializationDataProcessor>();
 
             return services;

--- a/src/OSK.Storage.Local.Cryptography/ServiceCollectionExtensions.cs
+++ b/src/OSK.Storage.Local.Cryptography/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using OSK.Security.Cryptography;
 using OSK.Storage.Local.Cryptography.Internal.Services;
 
 namespace OSK.Storage.Local.Cryptography
@@ -7,7 +8,9 @@ namespace OSK.Storage.Local.Cryptography
     {
         public static IServiceCollection AddLocalStorageCryptography(this IServiceCollection services)
         {
-            services.AddSerializationRawDataProcessor<CryptographySerializationDataProcessor>();
+            services
+                .AddCryptography()
+                .AddSerializationRawDataProcessor<CryptographySerializationDataProcessor>();
 
             return services;
         }

--- a/src/OSK.Storage.Local.UnitTests/Helpers/TestKeyRepository.cs
+++ b/src/OSK.Storage.Local.UnitTests/Helpers/TestKeyRepository.cs
@@ -8,9 +8,11 @@ namespace OSK.Storage.Local.UnitTests.Helpers
     {
         private static readonly AesKeyInformation KeyInformation = AesKeyInformation.New(128);
 
+        internal AesKeyInformation CustomKeyInformation { get; set; }
+
         public ValueTask<ICryptographicKeyInformation> GetCryptographicKeyAsync(CancellationToken cancellationToken = default)
         {
-            return new ValueTask<ICryptographicKeyInformation>(KeyInformation);
+            return new ValueTask<ICryptographicKeyInformation>(CustomKeyInformation ?? KeyInformation);
         }
     }
 }

--- a/src/OSK.Storage.Local.UnitTests/Internal/Services/EndToEnd.cs
+++ b/src/OSK.Storage.Local.UnitTests/Internal/Services/EndToEnd.cs
@@ -119,8 +119,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             // Arrange
             _services.TryAddTransient<ICryptographicKeyRepository, TestKeyRepository>();
             _services
-                .AddCryptography()
-                    .AddLocalStorageCryptography()
+                .AddLocalStorageCryptography()
                     .AddAesKeyService()
                 .AddLocalStorageSnappierCompression()
                 .AddSerializerExtensionDescriptor<IJsonSerializer>(".testExtension");

--- a/src/OSK.Storage.Local.UnitTests/Internal/Services/EndToEnd.cs
+++ b/src/OSK.Storage.Local.UnitTests/Internal/Services/EndToEnd.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using OSK.Extensions.Object.DeepEquals;
 using OSK.Extensions.Serialization.SystemTextJson.Polymorphism;
 using OSK.Extensions.Serialization.YamlDotNet.Polymorphism;
+using OSK.Security.Cryptography;
+using OSK.Security.Cryptography.Aes;
 using OSK.Security.Cryptography.Aes.Models;
 using OSK.Serialization.Abstractions.Json;
 using OSK.Serialization.Binary.Sharp;
@@ -117,7 +119,9 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             // Arrange
             _services.TryAddTransient<ICryptographicKeyRepository, TestKeyRepository>();
             _services
-                .AddLocalStorageCryptography()
+                .AddCryptography()
+                    .AddLocalStorageCryptography()
+                    .AddAesKeyService()
                 .AddLocalStorageSnappierCompression()
                 .AddSerializerExtensionDescriptor<IJsonSerializer>(".testExtension");
 

--- a/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
+++ b/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.2" />
+		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.1.0" />
 		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />

--- a/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
+++ b/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
@@ -10,6 +10,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="OSK.Extensions.Object.DeepEquals" Version="1.1.0" />
 		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
 		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.2" />

--- a/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
+++ b/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
@@ -122,7 +122,7 @@ namespace OSK.Storage.Local.Internal.Services
             }
             if (!File.Exists(fullFilePath))
             {
-                return _outputFactory.NotFound<StorageObject>($"The following filwe {fullFilePath} did not exist.");
+                return _outputFactory.NotFound<StorageObject>($"The following file {fullFilePath} did not exist.");
             }
 
             var getLocalObjectResult = await GetLocalStorageObjectAsync(fullFilePath, keepStreamOpen: true, cancellationToken);

--- a/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
+++ b/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
@@ -122,18 +122,13 @@ namespace OSK.Storage.Local.Internal.Services
             }
             if (!File.Exists(fullFilePath))
             {
-                return _outputFactory.NotFound<StorageObject>($"The following file {fullFilePath} did not exist.");
+                return _outputFactory.NotFound<StorageObject>($"The following filwe {fullFilePath} did not exist.");
             }
 
             var getLocalObjectResult = await GetLocalStorageObjectAsync(fullFilePath, keepStreamOpen: true, cancellationToken);
             if (!getLocalObjectResult.IsSuccessful)
             {
                 return getLocalObjectResult.AsType<StorageObject>();
-            }
-
-            if (getLocalObjectResult.Value.IsEncrypted) 
-            {
-                getLocalObjectResult.Value.DataStream.Position = LocalStorageSignature.Length;
             }
 
             return _outputFactory.Success((StorageObject)new LocalStorageObject(

--- a/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
+++ b/src/OSK.Storage.Local/Internal/Services/LocalStorageService.cs
@@ -131,6 +131,11 @@ namespace OSK.Storage.Local.Internal.Services
                 return getLocalObjectResult.AsType<StorageObject>();
             }
 
+            if (getLocalObjectResult.Value.IsEncrypted) 
+            {
+                getLocalObjectResult.Value.DataStream.Position = LocalStorageSignature.Length;
+            }
+
             return _outputFactory.Success((StorageObject)new LocalStorageObject(
                 getLocalObjectResult.Value.DataStream,
                 new StorageMetaData(

--- a/src/OSK.Storage.Local/MemoryStreamExtensions.cs
+++ b/src/OSK.Storage.Local/MemoryStreamExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OSK.Storage.Local
+{
+    public static class MemoryStreamExtensions
+    {
+        public static async Task<byte[]> ToArrayAsync(this MemoryStream memoryStream, int startIndex)
+        {
+            memoryStream.Position = startIndex;
+
+            var byteArray = new byte[ memoryStream.Length - startIndex ];
+            var currentIndex = 0;
+            do
+            {
+                var byteReadCount = (int)Math.Min(1024, memoryStream.Length - startIndex - currentIndex);
+                await memoryStream.ReadAsync(byteArray, currentIndex, byteReadCount);
+                currentIndex += byteReadCount;
+            } while (currentIndex + startIndex < memoryStream.Length);
+
+            return byteArray;
+        }
+    }
+}

--- a/src/OSK.Storage.Local/MemoryStreamExtensions.cs
+++ b/src/OSK.Storage.Local/MemoryStreamExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OSK.Storage.Local
@@ -7,7 +8,7 @@ namespace OSK.Storage.Local
     public static class MemoryStreamExtensions
     {
         public static async Task<byte[]> ToArrayAsync(this MemoryStream memoryStream, int startIndex = 0, 
-            int bytesReadPerIteration = 1024)
+            int bytesReadPerIteration = 1024, CancellationToken cancellationToken = default)
         {
             memoryStream.Position = startIndex;
 
@@ -16,7 +17,7 @@ namespace OSK.Storage.Local
             do
             {
                 var byteReadCount = (int)Math.Min(bytesReadPerIteration, memoryStream.Length - startIndex - currentIndex);
-                await memoryStream.ReadAsync(byteArray, currentIndex, byteReadCount);
+                await memoryStream.ReadAsync(byteArray, currentIndex, byteReadCount, cancellationToken);
                 currentIndex += byteReadCount;
             } while (currentIndex + startIndex < memoryStream.Length);
 

--- a/src/OSK.Storage.Local/MemoryStreamExtensions.cs
+++ b/src/OSK.Storage.Local/MemoryStreamExtensions.cs
@@ -6,7 +6,8 @@ namespace OSK.Storage.Local
 {
     public static class MemoryStreamExtensions
     {
-        public static async Task<byte[]> ToArrayAsync(this MemoryStream memoryStream, int startIndex)
+        public static async Task<byte[]> ToArrayAsync(this MemoryStream memoryStream, int startIndex = 0, 
+            int bytesReadPerIteration = 1024)
         {
             memoryStream.Position = startIndex;
 
@@ -14,7 +15,7 @@ namespace OSK.Storage.Local
             var currentIndex = 0;
             do
             {
-                var byteReadCount = (int)Math.Min(1024, memoryStream.Length - startIndex - currentIndex);
+                var byteReadCount = (int)Math.Min(bytesReadPerIteration, memoryStream.Length - startIndex - currentIndex);
                 await memoryStream.ReadAsync(byteArray, currentIndex, byteReadCount);
                 currentIndex += byteReadCount;
             } while (currentIndex + startIndex < memoryStream.Length);

--- a/src/OSK.Storage.Local/Models/LocalStorageObject.cs
+++ b/src/OSK.Storage.Local/Models/LocalStorageObject.cs
@@ -77,7 +77,7 @@ namespace OSK.Storage.Local.Models
         private async ValueTask<byte[]> ReadStreamBytesAsync(CancellationToken cancellationToken)
         {
             using var contentStream = await GetContentAsMemoryStreamAsync(cancellationToken);
-            return contentStream.ToArray();
+            return await contentStream.ToArrayAsync();
         }
 
         private async ValueTask<MemoryStream> GetContentAsMemoryStreamAsync(CancellationToken cancellationToken)

--- a/src/OSK.Storage.Local/Models/LocalStorageObject.cs
+++ b/src/OSK.Storage.Local/Models/LocalStorageObject.cs
@@ -76,17 +76,25 @@ namespace OSK.Storage.Local.Models
 
         private async ValueTask<byte[]> ReadStreamBytesAsync(CancellationToken cancellationToken)
         {
+            using var contentStream = await GetContentAsMemoryStreamAsync(cancellationToken);
+            return contentStream.ToArray();
+        }
+
+        private async ValueTask<MemoryStream> GetContentAsMemoryStreamAsync(CancellationToken cancellationToken)
+        {
             if (Value is MemoryStream memoryStream)
             {
-                return memoryStream.ToArray();
+                return memoryStream;
             }
 
-            using var copyStream = new MemoryStream();
-            await Value.CopyToAsync(copyStream, cancellationToken);
+            var contentStream = new MemoryStream();
+            await Value.CopyToAsync(contentStream, cancellationToken);
             await Value.FlushAsync(cancellationToken);
-            var array = copyStream.ToArray();
+            contentStream.Position = 0;
+
             Value.Dispose();
-            return array;
+
+            return contentStream;
         }
 
         #endregion

--- a/src/OSK.Storage.Local/Models/LocalStorageObject.cs
+++ b/src/OSK.Storage.Local/Models/LocalStorageObject.cs
@@ -77,7 +77,7 @@ namespace OSK.Storage.Local.Models
         private async ValueTask<byte[]> ReadStreamBytesAsync(CancellationToken cancellationToken)
         {
             using var contentStream = await GetContentAsMemoryStreamAsync(cancellationToken);
-            return await contentStream.ToArrayAsync();
+            return await contentStream.ToArrayAsync(cancellationToken: cancellationToken);
         }
 
         private async ValueTask<MemoryStream> GetContentAsMemoryStreamAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Motivation
----
The current cryptography project automatically adds a dependency on the OSK AES project. This is undesired for any project that may not want to utilize AES cryptographic implementations, but there is also a side effect that duplicate algorithm descriptors could be added if individual projects unaware of the dependency attempt to add AES manually

Modifications
----
* Removed dependency on the AES project for the local storage cryptographic integration
* Updated unit tests for reusability/code maintenance
* Updated StreamAsAsync to use a ToArrayAsync implementation

Result
----
Issues from an AES dependency on the storage project integration are removed 

Fixes #13