### PR TITLE
Updating metadata/output packages (OSK-15)

### DIFF
--- a/src/OSK.Storage.Local.Compression.Snappier/Internal/Services/SnappierCompressionSerializationDataProcessor.cs
+++ b/src/OSK.Storage.Local.Compression.Snappier/Internal/Services/SnappierCompressionSerializationDataProcessor.cs
@@ -30,13 +30,13 @@ namespace OSK.Storage.Local.Compression.Snappier.Internal.Services
         public ValueTask<IOutput<byte[]>> ProcessPostSerializationAsync(byte[] data,
             CancellationToken cancellationToken = default)
         {
-            return new ValueTask<IOutput<byte[]>>(_outputFactory.Success(Snappy.CompressToArray(data)));
+            return new ValueTask<IOutput<byte[]>>(_outputFactory.Succeed(Snappy.CompressToArray(data)));
         }
 
         public ValueTask<IOutput<byte[]>> ProcessPreDeserializationAsync(byte[] data, 
             CancellationToken cancellationToken = default)
         {
-            return new ValueTask<IOutput<byte[]>>(_outputFactory.Success(Snappy.DecompressToArray(data)));
+            return new ValueTask<IOutput<byte[]>>(_outputFactory.Succeed(Snappy.DecompressToArray(data)));
         }
 
         #endregion

--- a/src/OSK.Storage.Local.Cryptography/Internal/Services/CryptographySerializationDataProcessor.cs
+++ b/src/OSK.Storage.Local.Cryptography/Internal/Services/CryptographySerializationDataProcessor.cs
@@ -38,14 +38,14 @@ namespace OSK.Storage.Local.Cryptography.Internal.Services
         {
             var keyService = await GetKeyService(cancellationToken);
             var encryptedData = await keyService.EncryptAsync(data, cancellationToken);
-            return _outputFactory.Success(encryptedData);
+            return _outputFactory.Succeed(encryptedData);
         }
 
         public async ValueTask<IOutput<byte[]>> ProcessPreDeserializationAsync(byte[] data, CancellationToken cancellationToken = default)
         {
             var keyService = await GetKeyService(cancellationToken);
             var decryptedData = await keyService.DecryptAsync(data, cancellationToken);
-            return _outputFactory.Success(decryptedData);
+            return _outputFactory.Succeed(decryptedData);
         }
 
         #endregion

--- a/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
+++ b/src/OSK.Storage.Local.Cryptography/OSK.Storage.Local.Cryptography.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
-		<PackageReference Include="OSK.Security.Cryptography" Version="2.1.0" />
+		<PackageReference Include="OSK.Security.Cryptography" Version="2.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.Cryptography/Ports/ICryptographicKeyRepository.cs
+++ b/src/OSK.Storage.Local.Cryptography/Ports/ICryptographicKeyRepository.cs
@@ -8,7 +8,7 @@ namespace OSK.Storage.Local.Cryptography.Ports
     /// <summary>
     /// A key repository that provides a cryptographic key to a cryptographic data processor when data manipulations are happening prior to storage"/>
     /// </summary>
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.ConsumerRequired)]
     public interface ICryptographicKeyRepository
     {
         ValueTask<ICryptographicKeyInformation> GetCryptographicKeyAsync(CancellationToken cancellationToken = default);

--- a/src/OSK.Storage.Local.UnitTests/Internal/Services/LocalStorageServiceTests.cs
+++ b/src/OSK.Storage.Local.UnitTests/Internal/Services/LocalStorageServiceTests.cs
@@ -25,7 +25,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
         
         private readonly IOutputFactory<LocalStorageService> _mockOutputFactory;
 
-        private readonly ILocalStorageService _localStorageService;
+        private readonly LocalStorageService _localStorageService;
         private readonly FileStorageFixture _fileStorageFixture;
 
         #endregion
@@ -50,7 +50,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             mockServiceProvider.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(ISerializerProvider))))
                 .Returns(mockSerializerProvider.Object);
 
-            _dataProcessors = new List<IRawDataProcessor>();
+            _dataProcessors = [];
 
             _localStorageService = new LocalStorageService(
                 _dataProcessors, mockSerializerProvider.Object,
@@ -139,7 +139,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             var mockCryptographicDataProcessor = new Mock<ICryptographicRawDataProcessor>();
             mockCryptographicDataProcessor.Setup(m => m.ProcessPostSerializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_mockOutputFactory.BadRequest<byte[]>("A bad day!"));
+                .ReturnsAsync(_mockOutputFactory.Fail<byte[]>("A bad day!", OutputSpecificityCode.InvalidParameter));
             _dataProcessors.Add(mockCryptographicDataProcessor.Object);
 
             var text = "Test Text";
@@ -168,7 +168,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             var mockCryptographicDataProcessor = new Mock<ICryptographicRawDataProcessor>();
             mockCryptographicDataProcessor.Setup(m => m.ProcessPostSerializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_mockOutputFactory.BadRequest<byte[]>("A bad day!"));
+                .ReturnsAsync(_mockOutputFactory.Fail<byte[]>("A bad day!", OutputSpecificityCode.InvalidParameter));
             _dataProcessors.Add(mockCryptographicDataProcessor.Object);
 
             var text = "Test Text";
@@ -266,7 +266,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             var mockCryptographicDataProcessor = new Mock<ICryptographicRawDataProcessor>();
             mockCryptographicDataProcessor.Setup(m => m.ProcessPostSerializationAsync(It.IsAny<byte[]>(),
             It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] data, CancellationToken _) => _mockOutputFactory.Success(data));
+                .ReturnsAsync((byte[] data, CancellationToken _) => _mockOutputFactory.Succeed(data));
             _dataProcessors.Add(mockCryptographicDataProcessor.Object);
 
             var text = "Test Text";
@@ -339,10 +339,10 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             var mockCryptographicDataProcessor = new Mock<ICryptographicRawDataProcessor>();
             mockCryptographicDataProcessor.Setup(m => m.ProcessPostSerializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_mockOutputFactory.Success(encryptedTestBytes));
+                .ReturnsAsync(_mockOutputFactory.Succeed(encryptedTestBytes));
             mockCryptographicDataProcessor.Setup(m => m.ProcessPreDeserializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(_mockOutputFactory.BadRequest<byte[]>("A bad day!"));
+                .ReturnsAsync(_mockOutputFactory.Fail<byte[]>("A bad day!", OutputSpecificityCode.InvalidParameter));
             _dataProcessors.Add(mockCryptographicDataProcessor.Object);
 
             // Act
@@ -449,10 +449,10 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             var mockCryptographicDataProcessor = new Mock<ICryptographicRawDataProcessor>();
             mockCryptographicDataProcessor.Setup(m => m.ProcessPostSerializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Success(bytes));
+                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Succeed(bytes));
             mockCryptographicDataProcessor.Setup(m => m.ProcessPreDeserializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Success(bytes));
+                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Succeed(bytes));
             _dataProcessors.Add(mockCryptographicDataProcessor.Object);
 
             var encryptedFileName = "encryptedTestFile";
@@ -504,10 +504,10 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             var mockCryptographicDataProcessor = new Mock<ICryptographicRawDataProcessor>();
             mockCryptographicDataProcessor.Setup(m => m.ProcessPostSerializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Success(bytes));
+                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Succeed(bytes));
             mockCryptographicDataProcessor.Setup(m => m.ProcessPreDeserializationAsync(It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Success(bytes));
+                .ReturnsAsync((byte[] bytes, CancellationToken _) => _mockOutputFactory.Succeed(bytes));
             _dataProcessors.Add(mockCryptographicDataProcessor.Object);
 
             var encryptedFileName = "encryptedTestFile";
@@ -582,8 +582,8 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
             {
                 Name = "Hello",
                 Date = DateTime.UtcNow,
-                Data = new List<TestParentData>()
-                {
+                Data =
+                [
                     new TestChildData()
                     {
                         A = 1,
@@ -600,7 +600,7 @@ namespace OSK.Storage.Local.UnitTests.Internal.Services
                             B = "The Answers Are In"
                         }
                     }
-                }
+                ]
             };
 
             var path = _fileStorageFixture.GetFilePath("data.persisted");

--- a/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
+++ b/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
@@ -13,15 +13,15 @@
 		<PackageReference Include="OSK.Extensions.Object.DeepEquals" Version="1.1.0" />
 		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
-		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.2" />
+		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="2.1.1" />
 		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.1.0" />
 		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Polymorphism.Discriminators" Version="1.0.0" />
 		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.2" />
-		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/OSK.Storage.Local/OSK.Storage.Local.csproj
+++ b/src/OSK.Storage.Local/OSK.Storage.Local.csproj
@@ -13,8 +13,8 @@
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-		<PackageReference Include="MimeTypesMap" Version="1.0.8" />
-		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.5.2" />
+		<PackageReference Include="MimeTypesMap" Version="1.0.9" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="2.1.1" />
 		<PackageReference Include="OSK.Serialization.Abstractions" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Binary" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Json" Version="1.1.3" />

--- a/src/OSK.Storage.Local/Ports/ICryptographicRawDataProcessor.cs
+++ b/src/OSK.Storage.Local/Ports/ICryptographicRawDataProcessor.cs
@@ -5,7 +5,7 @@ namespace OSK.Storage.Local.Ports
     /// <summary>
     /// Represents a <see cref="IRawDataProcessor"/> that is focused on cryptographic encryption functions. This is meant to be used for encryption related purposes; for non-ecryption cryptographic purposes, please add a <see cref="IRawDataProcessor"/> instead. 
     /// </summary>
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationOptional)]
     public interface ICryptographicRawDataProcessor: IRawDataProcessor
     {
     }

--- a/src/OSK.Storage.Local/Ports/ILocalStorageService.cs
+++ b/src/OSK.Storage.Local/Ports/ILocalStorageService.cs
@@ -4,7 +4,7 @@ using OSK.Storage.Local.Options;
 
 namespace OSK.Storage.Local.Ports
 {
-    [HexagonalPort(HexagonalPort.Primary)]
+    [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided, HexagonalIntegrationType.ConsumerPointOfEntry)]
     public interface ILocalStorageService : IStorageService<LocalSaveOptions, FileSearchOptions>
     {
     }

--- a/src/OSK.Storage.Local/Ports/IRawDataProcessor.cs
+++ b/src/OSK.Storage.Local/Ports/IRawDataProcessor.cs
@@ -11,7 +11,7 @@ namespace OSK.Storage.Local.Ports
     /// This provides methods for serialization and deserialization to ensure that any processing for storage can be reversed if necessary so the raw data can be 
     /// successfully converted back into an object
     /// </summary>
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationOptional)]
     public interface IRawDataProcessor
     {
         /// <summary>

--- a/src/OSK.Storage.Local/Ports/ISerializerProvider.cs
+++ b/src/OSK.Storage.Local/Ports/ISerializerProvider.cs
@@ -6,7 +6,7 @@ namespace OSK.Storage.Local.Ports
     /// <summary>
     /// Retrives a valid <see cref="ISerializer"/> that is capable of serializing and deserializing a given file path
     /// </summary>
-    [HexagonalPort(HexagonalPort.Primary)]
+    [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
     public interface ISerializerProvider
     {
         ISerializer GetSerializer(string filePath);


### PR DESCRIPTION
Motivation
----
New updates for Hexagonal Metadata and Outputs have been published and the project should be using them

Modifications
----
* Updated to latest Hexagonal metadata
* Updated to latest Outputs

Result
----
Project is using the latest changes of core packages

Fixes #15