### PR TITLE
Update dependencies (OSK-17)

### DIFF
--- a/src/OSK.Storage.Local.Compression.Snappier/OSK.Storage.Local.Compression.Snappier.csproj
+++ b/src/OSK.Storage.Local.Compression.Snappier/OSK.Storage.Local.Compression.Snappier.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-		<PackageReference Include="Snappier" Version="1.1.6" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<PackageReference Include="Snappier" Version="1.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
+++ b/src/OSK.Storage.Local.UnitTests/OSK.Storage.Local.UnitTests.csproj
@@ -6,14 +6,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-		<PackageReference Include="OSK.Extensions.Object.DeepEquals" Version="1.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+		<PackageReference Include="OSK.Extensions.Object.DeepEquals" Version="1.1.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.SystemTextJson.Polymorphism" Version="1.0.2" />
 		<PackageReference Include="OSK.Extensions.Serialization.YamlDotNet.Polymorphism" Version="1.0.1" />
-		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="2.1.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="2.2.0" />
 		<PackageReference Include="OSK.Security.Cryptography.Aes" Version="1.1.0" />
 		<PackageReference Include="OSK.Serialization.Binary.Sharp" Version="1.0.1" />
 		<PackageReference Include="OSK.Serialization.Json.SystemTextJson" Version="1.0.1" />
@@ -21,7 +21,7 @@
 		<PackageReference Include="OSK.Serialization.Yaml.YamlDotNet" Version="1.0.2" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/OSK.Storage.Local/OSK.Storage.Local.csproj
+++ b/src/OSK.Storage.Local/OSK.Storage.Local.csproj
@@ -12,14 +12,14 @@
 	
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
 		<PackageReference Include="MimeTypesMap" Version="1.0.9" />
-		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="2.1.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="2.2.0" />
 		<PackageReference Include="OSK.Serialization.Abstractions" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Binary" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Json" Version="1.1.3" />
 		<PackageReference Include="OSK.Serialization.Abstractions.Yaml" Version="1.1.3" />
-		<PackageReference Include="OSK.Storage.Abstractions" Version="1.1.0" />
+		<PackageReference Include="OSK.Storage.Abstractions" Version="2.0.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----
The latest version of OSK Storage abstractions was released for ouptut v2 support, so should be consistent and use that

Modifications
----
* Updated all dependencies

Result
----
OSK ouptut v2 won't break in builds

Fixes #17